### PR TITLE
feat: add destructible Building cell type with toolbar button

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,7 +1,7 @@
 use crate::render::find_cursor_cell;
 use crate::persistence;
 use crate::simulation::{
-    Cell, Grid, MAX_WATER_KG, build_depth_pressure, step_objects, step_simulation,
+    Cell, Grid, MAX_WATER_KG, build_depth_pressure, step_buildings, step_objects, step_simulation,
 };
 use rand::thread_rng;
 use crate::undo::UndoStack;
@@ -34,6 +34,7 @@ impl Plugin for GridPlugin {
                 Update,
                 (
                     simulate_objects,
+                    simulate_buildings_system,
                     flow_water,
                     simulate_flow,
                     handle_input,
@@ -103,6 +104,8 @@ pub enum SelectedTool {
     Spring,
     /// Place a `Drain` (permanent water sink).
     Drain,
+    /// Place a destructible `Building` that collapses under water pressure.
+    Building { weight: f32, threshold: f32 },
 }
 
 #[derive(Resource, Default)]
@@ -202,6 +205,14 @@ fn handle_input(
                                 {
                                     Some(Cell::Drain)
                                 }
+                                SelectedTool::Building { weight, threshold }
+                                    if !matches!(
+                                        grid.get_cell(bx, by),
+                                        Cell::Building { .. }
+                                    ) =>
+                                {
+                                    Some(Cell::Building { weight, threshold })
+                                }
                                 _ => None,
                             };
                             if let Some(new) = new_cell {
@@ -264,6 +275,9 @@ fn handle_input(
     }
     if keyboard.just_pressed(KeyCode::KeyD) && !ctrl {
         *selected = SelectedTool::Drain;
+    }
+    if keyboard.just_pressed(KeyCode::KeyB) {
+        *selected = SelectedTool::Building { weight: 3000.0, threshold: 2500.0 };
     }
     if keyboard.just_pressed(KeyCode::KeyS) && ctrl {
         save_events.write(SaveRequested);
@@ -342,6 +356,7 @@ fn flow_water(mut grid: ResMut<Grid>, state: Res<GameState>) {
             Cell::Wall => Cell::Wall,
             Cell::Spring => Cell::Spring,
             Cell::Drain => Cell::Drain,
+            Cell::Building { weight, threshold } => Cell::Building { weight, threshold },
         };
         grid.set_cell(x, 0, new_cell);
     }
@@ -354,6 +369,15 @@ fn simulate_objects(mut grid: ResMut<Grid>, state: Res<GameState>, config: Res<G
     let mut rng = thread_rng();
     for _ in 0..state.sim_speed {
         step_objects(&mut grid, &mut rng, config.collision_destruction);
+    }
+}
+
+fn simulate_buildings_system(mut grid: ResMut<Grid>, state: Res<GameState>) {
+    if !state.water_flow {
+        return;
+    }
+    for _ in 0..state.sim_speed {
+        step_buildings(&mut grid);
     }
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -44,6 +44,7 @@ pub struct MaterialPalette {
     pub wall: Handle<StandardMaterial>,
     pub spring: Handle<StandardMaterial>,
     pub drain: Handle<StandardMaterial>,
+    pub building: Handle<StandardMaterial>,
     pub water: Vec<Handle<StandardMaterial>>,
     pub objects: Vec<Handle<StandardMaterial>>,
     pub heatmap: Vec<Handle<StandardMaterial>>,
@@ -58,6 +59,8 @@ fn build_palette(materials: &mut Assets<StandardMaterial>, froth: Handle<Image>)
     let wall = materials.add(Color::srgb(0.1, 0.1, 0.1));
     let spring = materials.add(Color::srgb(0.0, 0.8, 0.7));
     let drain = materials.add(Color::srgb(0.8, 0.4, 0.0));
+    // Warm tan/brown — distinct from water blue, object grey, wall dark, spring teal, drain orange
+    let building = materials.add(Color::srgb(0.76, 0.60, 0.42));
 
     let water: Vec<_> = (0..WATER_PALETTE_SIZE)
         .map(|i| {
@@ -96,6 +99,7 @@ fn build_palette(materials: &mut Assets<StandardMaterial>, froth: Handle<Image>)
         wall,
         spring,
         drain,
+        building,
         water,
         objects,
         heatmap,
@@ -211,6 +215,7 @@ fn render_grid(
                 let idx = (t * (OBJECT_PALETTE_SIZE - 1) as f32).round() as usize;
                 (0.8, &palette.objects[idx])
             }
+            Cell::Building { .. } => (1.0, &palette.building),
         };
         let scaled = h * CUBE_HEIGHT;
         transform.scale.y = scaled;
@@ -245,6 +250,7 @@ fn render_heat_grid_3d(
             Cell::Spring => 1.0,
             Cell::Drain => 0.3,
             Cell::Object(_) => 0.8,
+            Cell::Building { .. } => 1.0,
         };
         let scaled = h * CUBE_HEIGHT;
         transform.scale.y = scaled;
@@ -262,6 +268,7 @@ fn cell_surface_y(cell: &Cell) -> f32 {
         Cell::Spring => 1.0,
         Cell::Drain => 0.3,
         Cell::Object(_) => 0.8,
+        Cell::Building { .. } => 1.0,
     };
     h * CUBE_HEIGHT
 }
@@ -382,7 +389,7 @@ fn compute_arrow_info(
             };
             p_left.max(p_right).max(p_below)
         }
-        Cell::Wall => return None,
+        Cell::Wall | Cell::Building { .. } => return None,
     };
 
     let net_y = (raw_pressure - weight).max(0.0);
@@ -457,7 +464,8 @@ fn draw_flow_arrows(
 
     let weight = match *selected {
         SelectedTool::Block(w) => w,
-        _ => 200.0,
+        SelectedTool::Building { weight, .. } => weight,
+        SelectedTool::Eraser | SelectedTool::Spring | SelectedTool::Drain => 200.0,
     };
 
     let arrow_y = CUBE_HEIGHT + 0.5;
@@ -502,6 +510,7 @@ fn draw_hover_cursor(
         SelectedTool::Spring => 1.0,
         SelectedTool::Drain => 0.3,
         SelectedTool::Eraser => 0.15,
+        SelectedTool::Building { .. } => 1.0,
     };
     let scaled = h * CUBE_HEIGHT;
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -20,6 +20,8 @@ pub enum Cell {
     Spring,
     /// A permanent water sink; always treated as empty so water flows in.
     Drain,
+    /// A destructible building. Collapses into debris when depth pressure >= threshold.
+    Building { weight: f32, threshold: f32 },
 }
 
 /// The simulation grid. Cells are stored in row-major order: index = `y * width + x`.
@@ -77,7 +79,7 @@ fn water_fill(cell: &Cell) -> Option<f32> {
     match cell {
         Cell::Water(f) => Some(*f),
         Cell::Spring => Some(MAX_WATER_KG),
-        _ => None,
+        Cell::Air | Cell::Object(_) | Cell::Wall | Cell::Drain | Cell::Building { .. } => None,
     }
 }
 
@@ -86,7 +88,7 @@ fn flow_capacity(cell: &Cell) -> Option<f32> {
         Cell::Water(f) => Some(*f),
         Cell::Air => Some(0.0),
         Cell::Drain => Some(0.0), // drain appears empty — water always flows in
-        _ => None,
+        Cell::Object(_) | Cell::Wall | Cell::Spring | Cell::Building { .. } => None,
     }
 }
 
@@ -229,6 +231,12 @@ pub fn build_depth_pressure(grid: &Grid) -> Vec<f32> {
                     water_below.clear();
                     depth[y * width + x] = 0.0;
                 }
+                Cell::Building { .. } => {
+                    // Building receives the incoming pressure (used for collapse check)
+                    // and blocks further propagation downward.
+                    depth[y * width + x] = pressure;
+                    water_below.clear();
+                }
             }
         }
     }
@@ -268,7 +276,7 @@ pub fn build_flow_distance(grid: &Grid) -> Vec<u32> {
                 continue;
             }
             match grid.cells[nidx] {
-                Cell::Wall => {} // walls block flow path
+                Cell::Wall | Cell::Building { .. } => {} // block flow path
                 _ => {
                     dist[nidx] = d + 1;
                     queue.push_back(nidx);
@@ -484,7 +492,7 @@ pub fn step_objects(grid: &mut Grid, rng: &mut impl Rng, collision_destruction: 
         // we may mutate new_cells below for collision destruction.
         let effective_dst = {
             let is_blocked = |idx: usize| -> bool {
-                matches!(new_cells[idx], Cell::Wall | Cell::Spring | Cell::Drain)
+                matches!(new_cells[idx], Cell::Wall | Cell::Spring | Cell::Drain | Cell::Building { .. })
                     || (matches!(new_cells[idx], Cell::Object(_)) && !moved_srcs.contains(&idx))
             };
             let primary_hits_object = matches!(new_cells[intent.dst], Cell::Object(_))
@@ -528,6 +536,61 @@ pub fn step_objects(grid: &mut Grid, rng: &mut impl Rng, collision_destruction: 
     }
 
     grid.cells = new_cells;
+}
+
+/// Check every Building cell. If the accumulated depth pressure exceeds its
+/// threshold, collapse it: replace the building with Air and scatter up to
+/// 3 `Object(weight/3)` debris pieces into neighbouring cells (left, right,
+/// above — skipping Wall, Spring, Drain, and other Buildings).
+pub fn step_buildings(grid: &mut Grid) {
+    let width = grid.width;
+    let height = grid.height;
+    let depth = build_depth_pressure(grid);
+
+    // Collect all buildings that should collapse this tick before mutating.
+    let mut to_collapse: Vec<(usize, usize)> = Vec::new();
+    for y in 0..height {
+        for x in 0..width {
+            if let Cell::Building { threshold, .. } = grid.cells[y * width + x] {
+                if depth[y * width + x] >= threshold {
+                    to_collapse.push((x, y));
+                }
+            }
+        }
+    }
+
+    for (bx, by) in to_collapse {
+        let weight = if let Cell::Building { weight, .. } = grid.cells[by * width + bx] {
+            weight
+        } else {
+            continue;
+        };
+
+        // Replace the building with Air first so neighbours can be used.
+        grid.cells[by * width + bx] = Cell::Air;
+
+        // Candidate neighbours: left, right, above (prefer those directions per spec).
+        let candidates: &[(isize, isize)] = &[(-1, 0), (1, 0), (0, -1)];
+        let mut spawned = 0;
+        for &(dx, dy) in candidates {
+            if spawned >= 3 {
+                break;
+            }
+            let nx = bx as isize + dx;
+            let ny = by as isize + dy;
+            if nx < 0 || ny < 0 || nx >= width as isize || ny >= height as isize {
+                continue;
+            }
+            let nidx = ny as usize * width + nx as usize;
+            match grid.cells[nidx] {
+                Cell::Wall | Cell::Spring | Cell::Drain | Cell::Building { .. } => continue,
+                _ => {
+                    grid.cells[nidx] = Cell::Object(weight / 3.0);
+                    spawned += 1;
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -898,6 +961,81 @@ mod tests {
             matches!(grid.cells[1 * 4 + 2], Cell::Object(_)),
             "victim should be untouched with collision_destruction off"
         );
+    }
+
+    #[test]
+    fn building_survives_below_threshold() {
+        // 3-wide, 4-tall grid.
+        // y=0: Water(MAX_WATER_KG)  y=1: Building  y=2,3: Air
+        // Pressure on building at y=1 is below its threshold.
+        let mut cells = vec![Cell::Air; 3 * 4];
+        cells[0 * 3 + 1] = Cell::Water(MAX_WATER_KG);
+        cells[1 * 3 + 1] = Cell::Building { weight: 3000.0, threshold: 99999.0 };
+        let mut grid = make_grid(3, 4, cells);
+
+        step_buildings(&mut grid);
+
+        assert!(
+            matches!(grid.cells[1 * 3 + 1], Cell::Building { .. }),
+            "Building should survive when pressure is below threshold"
+        );
+    }
+
+    #[test]
+    fn building_collapses_and_spawns_three_debris() {
+        // Place water directly above building so pressure ≥ threshold.
+        // Grid: width=5, height=5
+        //   y=0: [W, W, W(src), W, W]   — reservoir row seeds pressure
+        //   y=1: [Air, Air, Building, Air, Air]
+        //   y=2,3,4: Air
+        // With a low threshold the building collapses.
+        let width = 5;
+        let height = 5;
+        let mut cells = vec![Cell::Air; width * height];
+        for x in 0..width {
+            cells[0 * width + x] = Cell::Water(MAX_WATER_KG);
+        }
+        // Building at (2,1) with threshold=0 so it always collapses
+        cells[1 * width + 2] = Cell::Building { weight: 3000.0, threshold: 0.0 };
+        let mut grid = make_grid(width, height, cells);
+
+        step_buildings(&mut grid);
+
+        // Building cell should now be Air
+        assert!(
+            matches!(grid.cells[1 * width + 2], Cell::Air),
+            "Collapsed building should become Air"
+        );
+
+        // Count debris objects spawned
+        let debris_count = grid.cells.iter().filter(|c| matches!(c, Cell::Object(_))).count();
+        assert_eq!(debris_count, 3, "Should spawn exactly 3 debris objects");
+    }
+
+    #[test]
+    fn building_debris_weight_is_weight_divided_by_three() {
+        let width = 5;
+        let height = 5;
+        let mut cells = vec![Cell::Air; width * height];
+        for x in 0..width {
+            cells[0 * width + x] = Cell::Water(MAX_WATER_KG);
+        }
+        let building_weight = 3000.0f32;
+        cells[1 * width + 2] = Cell::Building { weight: building_weight, threshold: 0.0 };
+        let mut grid = make_grid(width, height, cells);
+
+        step_buildings(&mut grid);
+
+        for cell in &grid.cells {
+            if let Cell::Object(w) = cell {
+                assert!(
+                    (w - building_weight / 3.0).abs() < 0.01,
+                    "Each debris piece should weigh weight/3 = {}, got {}",
+                    building_weight / 3.0,
+                    w
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ impl Plugin for UiPlugin {
                 handle_eraser_button,
                 handle_spring_button,
                 handle_drain_button,
+                handle_building_button,
                 update_tool_buttons,
                 handle_inlet_toggle,
                 update_inlet_button,
@@ -42,6 +43,9 @@ struct SpringButton;
 
 #[derive(Component)]
 struct DrainButton;
+
+#[derive(Component)]
+struct BuildingButton;
 
 #[derive(Component)]
 pub struct InletButton;
@@ -294,6 +298,62 @@ fn setup_ui(mut commands: Commands) {
                             });
                         btn.spawn((
                             Text::new("Drain"),
+                            TextFont {
+                                font_size: 9.0,
+                                ..default()
+                            },
+                            TextColor(Color::WHITE),
+                        ));
+                    });
+
+                    // Building tool button — warm tan house icon
+                    grid.spawn((
+                        Button,
+                        Node {
+                            width: Val::Px(50.0),
+                            height: Val::Px(56.0),
+                            flex_direction: FlexDirection::Column,
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::FlexEnd,
+                            padding: UiRect::bottom(Val::Px(4.0)),
+                            ..default()
+                        },
+                        BackgroundColor(Color::srgb(0.55, 0.55, 0.58)),
+                        BuildingButton,
+                    ))
+                    .with_children(|btn| {
+                        // House-shaped icon: narrow roof strip + wider body
+                        btn.spawn((Node {
+                            width: Val::Px(50.0),
+                            height: Val::Px(38.0),
+                            flex_direction: FlexDirection::Column,
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            row_gap: Val::Px(1.0),
+                            ..default()
+                        },))
+                            .with_children(|icon| {
+                                // Roof: narrower, darker strip on top
+                                icon.spawn((
+                                    Node {
+                                        width: Val::Px(18.0),
+                                        height: Val::Px(5.0),
+                                        ..default()
+                                    },
+                                    BackgroundColor(Color::srgb(0.55, 0.38, 0.22)),
+                                ));
+                                // Body: wider, warm tan rectangle
+                                icon.spawn((
+                                    Node {
+                                        width: Val::Px(14.0),
+                                        height: Val::Px(10.0),
+                                        ..default()
+                                    },
+                                    BackgroundColor(Color::srgb(0.76, 0.60, 0.42)),
+                                ));
+                            });
+                        btn.spawn((
+                            Text::new("Build"),
                             TextFont {
                                 font_size: 9.0,
                                 ..default()
@@ -656,6 +716,17 @@ fn handle_drain_button(
     }
 }
 
+fn handle_building_button(
+    q: Query<&Interaction, (Changed<Interaction>, With<BuildingButton>)>,
+    mut selected: ResMut<SelectedTool>,
+) {
+    for interaction in &q {
+        if *interaction == Interaction::Pressed {
+            *selected = SelectedTool::Building { weight: 3000.0, threshold: 2500.0 };
+        }
+    }
+}
+
 fn update_tool_buttons(
     mut weight_query: Query<
         (&WeightButton, &mut BackgroundColor),
@@ -663,6 +734,7 @@ fn update_tool_buttons(
             Without<EraserButton>,
             Without<SpringButton>,
             Without<DrainButton>,
+            Without<BuildingButton>,
         ),
     >,
     mut eraser_query: Query<
@@ -671,10 +743,18 @@ fn update_tool_buttons(
             With<EraserButton>,
             Without<SpringButton>,
             Without<DrainButton>,
+            Without<BuildingButton>,
         ),
     >,
-    mut spring_query: Query<&mut BackgroundColor, (With<SpringButton>, Without<DrainButton>)>,
-    mut drain_query: Query<&mut BackgroundColor, With<DrainButton>>,
+    mut spring_query: Query<
+        &mut BackgroundColor,
+        (With<SpringButton>, Without<DrainButton>, Without<BuildingButton>),
+    >,
+    mut drain_query: Query<
+        &mut BackgroundColor,
+        (With<DrainButton>, Without<BuildingButton>),
+    >,
+    mut building_query: Query<&mut BackgroundColor, With<BuildingButton>>,
     selected: Res<SelectedTool>,
 ) {
     if !selected.is_changed() {
@@ -706,6 +786,13 @@ fn update_tool_buttons(
     }
     for mut color in &mut drain_query {
         *color = if *selected == SelectedTool::Drain {
+            BackgroundColor(selected_color)
+        } else {
+            BackgroundColor(unselected_color)
+        };
+    }
+    for mut color in &mut building_query {
+        *color = if matches!(*selected, SelectedTool::Building { .. }) {
             BackgroundColor(selected_color)
         } else {
             BackgroundColor(unselected_color)


### PR DESCRIPTION
Implements the destructible Building cell type from issue #15, including a toolbar button.

- `Cell::Building { weight, threshold }` with collapse logic and serde
- Collapse mechanic: pressure check + 3 debris objects spawned to neighbours
- `SelectedTool::Building` + `B` key shortcut
- Toolbar button with house-shaped icon (highlights when selected)
- Warm tan rendering
- Save/load and undo/redo work automatically
- 3 unit tests

Closes #15

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-15-20260317-1410`](https://github.com/jbehadev/bluerush/tree/claude/issue-15-20260317-1410